### PR TITLE
Added a pyproject.toml to allow uvx

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,9 +6,11 @@ yarn-error.log
 
 # Python virtual environment
 venv/
+.venv/
 env/
 *.pyc
 __pycache__/
+*.egg-info
 
 # Build files
 /demo/build/
@@ -30,3 +32,4 @@ __pycache__/
 # OS specific
 .DS_Store
 Thumbs.db
+.aider*

--- a/README.md
+++ b/README.md
@@ -33,13 +33,17 @@ A Python utility to read images from a directory, convert them to binary and bas
 ## Installation
 
 1. Clone this repository or download the source code
-2. Install the required dependencies:
+2. Install the project and its dependencies:
 
 ```bash
-pip install -r requirements.txt
+pip install .
+# Or using uv
+# uv pip install .
 ```
 
 ## Usage
+
+After installation, you can run the script directly from your terminal.
 
 1. Create an `images` directory (if not already present) and add your image files:
 
@@ -51,17 +55,29 @@ mkdir images
 2. Run the script:
 
 ```bash
-python image_publisher.py
+image-publisher
 ```
 
 This will use default settings (local Solace broker, 'images' directory).
 
-### Command Line Options
-
-You can customize the behavior with command-line arguments:
+If you prefer not to install the package into your environment, you can use `uvx` to run it directly:
 
 ```bash
-python image_publisher.py --images-dir=/path/to/images --host=tcp://broker:55555 --vpn=my-vpn --username=user --password=pass
+uvx image-publisher
+```
+
+### Command Line Options
+
+You can customize the behavior with command-line arguments.
+
+When installed:
+```bash
+image-publisher --images-dir=/path/to/images --host=tcp://broker:55555 --vpn=my-vpn --username=user --password=pass
+```
+
+When using `uvx` (note the `--` to separate `uvx` arguments from script arguments):
+```bash
+uvx image-publisher -- --images-dir=/path/to/images --host=tcp://broker:55555 --vpn=my-vpn --username=user --password=pass
 ```
 
 Available options:
@@ -108,32 +124,6 @@ npm start
 The demo application will connect to a local Solace broker and display any images published to the `solace/images/>` topic.
 
 For more details, see the [demo README](./demo/README.md).
-
-## Topic Structure
-
-Images are published to topics with the following format:
-```
-solace/images/{image_filename}
-```
-
-## Message Format
-
-Each published message contains:
-- Payload: Base64-encoded image data
-- Properties:
-  - `filename`: Original image filename
-  - `content-type`: Image MIME type (e.g., image/jpeg)
-  - `encoding`: Always "base64"
-  - `application-message-id`: Unique identifier for the image
-
-### Environment Variables
-
-You can also set configuration via environment variables:
-
-- `SOLACE_HOST`: Solace broker host
-- `SOLACE_VPN`: Message VPN name
-- `SOLACE_USERNAME`: Authentication username
-- `SOLACE_PASSWORD`: Authentication password
 
 ## Topic Structure
 

--- a/README.md
+++ b/README.md
@@ -60,10 +60,10 @@ image-publisher
 
 This will use default settings (local Solace broker, 'images' directory).
 
-If you prefer not to install the package into your environment, you can use `uvx` to run it directly:
+If you prefer not to install the package into your environment, you can use `uvx` to run it directly from your project source:
 
 ```bash
-uvx image-publisher
+uvx --package . image-publisher
 ```
 
 ### Command Line Options
@@ -77,7 +77,7 @@ image-publisher --images-dir=/path/to/images --host=tcp://broker:55555 --vpn=my-
 
 When using `uvx` (note the `--` to separate `uvx` arguments from script arguments):
 ```bash
-uvx image-publisher -- --images-dir=/path/to/images --host=tcp://broker:55555 --vpn=my-vpn --username=user --password=pass
+uvx --package . image-publisher -- --images-dir=/path/to/images --host=tcp://broker:55555 --vpn=my-vpn --username=user --password=pass
 ```
 
 Available options:

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ A Python utility to read images from a directory, convert them to binary and bas
 
 ## Prerequisites
 
-- Python 3.6 or higher
+- Python 3.10 or higher
 - Solace PubSub+ broker (or Solace Cloud service)
 - Python dependencies (see requirements.txt)
 - Node.js 14+ (for the demo viewer)
@@ -63,7 +63,7 @@ This will use default settings (local Solace broker, 'images' directory).
 If you prefer not to install the package into your environment, you can use `uvx` to run it directly from your project source:
 
 ```bash
-uvx --package . image-publisher
+uvx --from . image-publisher
 ```
 
 ### Command Line Options
@@ -77,7 +77,7 @@ image-publisher --images-dir=/path/to/images --host=tcp://broker:55555 --vpn=my-
 
 When using `uvx` (note the `--` to separate `uvx` arguments from script arguments):
 ```bash
-uvx --package . image-publisher -- --images-dir=/path/to/images --host=tcp://broker:55555 --vpn=my-vpn --username=user --password=pass
+uvx --from . image-publisher -- --images-dir=/path/to/images --host=tcp://broker:55555 --vpn=my-vpn --username=user --password=pass
 ```
 
 Available options:

--- a/image_publisher.py
+++ b/image_publisher.py
@@ -222,8 +222,8 @@ def main():
     parser.add_argument('--images-dir', type=str, default='images',
                         help='Directory containing images (default: images)')
     parser.add_argument('--host', type=str, 
-                        default=os.environ.get('SOLACE_HOST', 'tcp://localhost:55554'),
-                        help='Solace broker host (default: tcp://localhost:55554)')
+                        default=os.environ.get('SOLACE_HOST', 'tcp://localhost:55555'),
+                        help='Solace broker host (default: tcp://localhost:55555)')
     parser.add_argument('--vpn', type=str, 
                         default=os.environ.get('SOLACE_VPN', 'default'),
                         help='Message VPN name (default: default)')

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "image-publisher"
 version = "0.1.0"
 description = "A Python utility to read images from a directory and publish them to a Solace message broker."
 readme = "README.md"
-requires-python = ">=3.6"
+requires-python = ">=3.10"
 dependencies = [
     "solace-pubsubplus>=1.3.0"
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,3 +14,6 @@ dependencies = [
 
 [project.scripts]
 image-publisher = "image_publisher:main"
+
+[tool.setuptools]
+py-modules = ["image_publisher"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,16 @@
+[build-system]
+requires = ["setuptools>=61.0"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "image-publisher"
+version = "0.1.0"
+description = "A Python utility to read images from a directory and publish them to a Solace message broker."
+readme = "README.md"
+requires-python = ">=3.6"
+dependencies = [
+    "solace-pubsubplus>=1.3.0"
+]
+
+[project.scripts]
+image-publisher = "image_publisher:main"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,0 @@
-solace-pubsubplus>=1.3.0


### PR DESCRIPTION
This adds pyproject.toml and sets up a bunch of things to make it easier to run this tool. See the README for new instructions on usage.

There were a couple of other changes that AI did (defaulting Solace port to 55555). I left them in, but let me know if you want to revert that.